### PR TITLE
Fix docker entrypoint shebang and license position

### DIFF
--- a/entry_point.sh
+++ b/entry_point.sh
@@ -1,7 +1,10 @@
+#!/usr/bin/env bash
+
 # Copyright (c) 2018, ARM Limited.
 # SPDX-License-Identifier: Apache-2.0
 
-#!/bin/bash -e
+# Exit on error
+set -e
 
 # 3. Prepare the sysroot
 if [ ! -d "$CC_WS/sysroot_docker" ]; then


### PR DESCRIPTION
The license was add before the shebang, which doesn't allow docker to run the script as an entry-point. I also update the shebang to a more supported "#!/usr/bin/env bash" version.

Change-Id: Ibe925462dbfbf35bc468855a8361475ddfff50bb
Signed-off-by: Louis Mayencourt <louis.mayencourt@arm.com>