### PR TITLE
Add sysroot Dockerfile examples for pre-built instructions

### DIFF
--- a/sysroot/Dockerfile_ubuntu_arm64_prebuilt
+++ b/sysroot/Dockerfile_ubuntu_arm64_prebuilt
@@ -1,0 +1,31 @@
+# Copyright (c) 2018, ARM Limited.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM arm64v8/ubuntu:bionic
+
+COPY ./qemu-user-static/* /usr/bin/
+
+# Set timezone
+RUN echo 'Etc/UTC' > /etc/timezone && \
+    ln -s /usr/share/zoneinfo/Etc/UTC /etc/localtime && \
+    apt-get update && apt-get install -q -y tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN apt update && apt install -y \
+    pkg-config \
+    lsb-release \
+    curl \
+    bash-completion \
+    gnupg2
+
+ENV LANG en_US.UTF-8
+ENV LC_ALL C.UTF-8
+
+RUN curl http://repo.ros2.org/repos.key | apt-key add -
+RUN sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main \
+    `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
+
+ENV ROS_DISTRO bouncy
+RUN apt-get update && apt-get install -y \
+    ros-$ROS_DISTRO-desktop && \
+    rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Add the Dockerfile used on the instructions on how to cross-compile
one or more packages against a pre-built ROS2 stack.

related to https://github.com/ros2/ros2_documentation/pull/29

Change-Id: I092f6706f0a91741e895ea1e9756a975e42d787d
Signed-off-by: Louis Mayencourt <louis.mayencourt@arm.com>