### PR TITLE
Fix for class-loader libz and pcre link issue

### DIFF
--- a/entry_point.sh
+++ b/entry_point.sh
@@ -32,13 +32,6 @@ export SYSROOT=$CC_WS/sysroot_docker
 export PYTHON_SOABI=cpython-36m-$TARGET_TRIPLE
 export ROS2_INSTALL_PATH=$CC_WS/ros2_ws/install
 
-
-# Hack to build class-loader
-## This is temporarily required because this libraires are not found on the
-## specified SYSROOT
-ln -s `pwd`/sysroot_docker/lib/$TARGET_TRIPLE/libz.so.1 /usr/lib/$TARGET_TRIPLE/libz.so
-ln -s `pwd`/sysroot_docker/lib/$TARGET_TRIPLE/libpcre.so.3 /usr/lib/$TARGET_TRIPLE/libpcre.so
-
 # Ignore some package
 touch \
     ros2_ws/src/ros2/rviz/COLCON_IGNORE \

--- a/sysroot/Dockerfile_ubuntu_arm64
+++ b/sysroot/Dockerfile_ubuntu_arm64
@@ -64,7 +64,8 @@ RUN python3 -m pip install -U \
 
 RUN apt install --no-install-recommends -y \
     libasio-dev \
-    libtinyxml2-dev
+    libtinyxml2-dev \
+    libssl-dev
 
 WORKDIR /ros2_ws
 RUN rosdep init
@@ -77,4 +78,6 @@ RUN rosdep install --from-paths src \
         fastrtps \
         libopensplice67 \
         rti-connext-dds-5.3.1 \
-        urdfdom_headers"
+        urdfdom_headers \
+        libpoco-dev \
+        libpocofoundation9"

--- a/sysroot/Dockerfile_ubuntu_armhf
+++ b/sysroot/Dockerfile_ubuntu_armhf
@@ -64,7 +64,8 @@ RUN python3 -m pip install -U \
 
 RUN apt install --no-install-recommends -y \
     libasio-dev \
-    libtinyxml2-dev
+    libtinyxml2-dev \
+    libssl-dev
 
 WORKDIR /ros2_ws
 RUN rosdep init
@@ -77,4 +78,6 @@ RUN rosdep install --from-paths src \
         fastrtps \
         libopensplice67 \
         rti-connext-dds-5.3.1 \
-        urdfdom_headers"
+        urdfdom_headers \
+        libpoco-dev \
+        libpocofoundation9"


### PR DESCRIPTION
The class-loader package fails if the pre-built binary of Poco
library is used. The PocoFoundationTargets.cmake file coming
with the pre-built binary have hardcoded paths to libz and libpcre
which makes the cross-compilation to fail.
This fix removes Poco library from the apt-get list and forces
to build it inside the poco_vendor ros2 packages.

related to: https://github.com/ros2/ros2_documentation/pull/29