### PR TITLE
Update for latest release (Crystal Clemmys)

### DIFF
--- a/Dockerfile_cc_for_arm
+++ b/Dockerfile_cc_for_arm
@@ -52,7 +52,7 @@ RUN apt-get install -y docker-ce
 
 # 2. Download ROS2 src
 ENV CC_WS /root/cc_ws
-ARG ROS2_VERSION=release-bouncy
+ARG ROS2_VERSION=release-latest
 
 WORKDIR $CC_WS/ros2_ws
 RUN mkdir src

--- a/entry_point.sh
+++ b/entry_point.sh
@@ -35,6 +35,13 @@ export SYSROOT=$CC_WS/sysroot_docker
 export PYTHON_SOABI=cpython-36m-$TARGET_TRIPLE
 export ROS2_INSTALL_PATH=$CC_WS/ros2_ws/install
 
+# Hack to find Poco
+## This is temporarily required to find the Poco libraries on the SYSROOT.
+## The exported target comming with the pre-build binaries has a hard-coded
+## path to "/usr/lib/<arch>/libz.so" and "/usr/lib/<arch>/libpcre.so"
+ln -s `pwd`/sysroot_docker/lib/$TARGET_TRIPLE/libz.so.1 /usr/lib/$TARGET_TRIPLE/libz.so
+ln -s `pwd`/sysroot_docker/lib/$TARGET_TRIPLE/libpcre.so.3 /usr/lib/$TARGET_TRIPLE/libpcre.so
+
 # Ignore some package
 touch \
     ros2_ws/src/ros2/rviz/COLCON_IGNORE \

--- a/entry_point.sh
+++ b/entry_point.sh
@@ -45,7 +45,7 @@ ln -s `pwd`/sysroot_docker/lib/$TARGET_TRIPLE/libpcre.so.3 /usr/lib/$TARGET_TRIP
 # Ignore some package
 touch \
     ros2_ws/src/ros2/rviz/COLCON_IGNORE \
-    ros2_ws/src/ros2/robot_state_publisher/COLCON_IGNORE
+    ros2_ws/src/ros-visualization/COLCON_IGNORE
 
 cd ros2_ws
 

--- a/sysroot/Dockerfile_ubuntu_arm
+++ b/sysroot/Dockerfile_ubuntu_arm
@@ -65,8 +65,7 @@ RUN python3 -m pip install -U \
 
 RUN apt install --no-install-recommends -y \
     libasio-dev \
-    libtinyxml2-dev \
-    libssl-dev
+    libtinyxml2-dev
 
 WORKDIR /ros2_ws
 RUN rosdep init
@@ -79,9 +78,7 @@ RUN rosdep install --from-paths src \
         fastrtps \
         libopensplice67 \
         rti-connext-dds-5.3.1 \
-        urdfdom_headers \
-        libpoco-dev \
-        libpocofoundation9"
+        urdfdom_headers"
 
 WORKDIR /
 RUN apt-get install -y symlinks

--- a/sysroot/Dockerfile_ubuntu_arm
+++ b/sysroot/Dockerfile_ubuntu_arm
@@ -77,6 +77,7 @@ RUN rosdep install --from-paths src \
         fastcdr \
         fastrtps \
         libopensplice67 \
+        libopensplice69 \
         rti-connext-dds-5.3.1 \
         urdfdom_headers"
 

--- a/sysroot/Dockerfile_ubuntu_arm64_prebuilt
+++ b/sysroot/Dockerfile_ubuntu_arm64_prebuilt
@@ -25,7 +25,7 @@ RUN curl http://repo.ros2.org/repos.key | apt-key add -
 RUN sh -c 'echo "deb [arch=amd64,arm64] http://repo.ros2.org/ubuntu/main \
     `lsb_release -cs` main" > /etc/apt/sources.list.d/ros2-latest.list'
 
-ENV ROS_DISTRO bouncy
+ENV ROS_DISTRO crystal
 RUN apt-get update && apt-get install -y \
     ros-$ROS_DISTRO-desktop && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
* ros-visualization package are ignored
* the new libopensplice69 is not installed as dependency

related to: https://github.com/ros2/ros2_documentation/pull/29