### PR TITLE
Clean docker container after extracting it

### DIFF
--- a/entry_point.sh
+++ b/entry_point.sh
@@ -17,6 +17,9 @@ if [ ! -d "$CC_WS/sysroot_docker" ]; then
     mkdir sysroot_docker
 
     tar -C sysroot_docker -xf sysroot_docker.tar lib usr
+
+    # Remove docker container
+    docker rm aarch64_sysroot
 fi
 
 # 4. Build


### PR DESCRIPTION
Remove the docker container after exporting to allow consecutive calls
of the entry-point script.