### PR TITLE
Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # Cross-compilation assets
 
 These are cross-compiling assets for ROS2.
-Documentation is in the wiki: https://index.ros.org/doc/ros2/Cross-compilation
+Documentation is in the wiki: https://index.ros.org/doc/ros2/Tutorials/Cross-compilation


### PR DESCRIPTION
This link is broken, but I'm not sure if the one I proposed is correct.  Please, let me know.

Also, is issue submission disabled for this repo?