### PR TITLE
Improve target file system export

### DIFF
--- a/entry_point.sh
+++ b/entry_point.sh
@@ -16,7 +16,7 @@ if [ ! -d "$CC_WS/sysroot_docker" ]; then
     docker container export -o sysroot_docker.tar aarch64_sysroot
     mkdir sysroot_docker
 
-    tar -C sysroot_docker -xf sysroot_docker.tar lib usr
+    tar -C sysroot_docker -xf sysroot_docker.tar lib usr etc
 
     # Remove docker container
     docker rm aarch64_sysroot

--- a/entry_point.sh
+++ b/entry_point.sh
@@ -38,8 +38,6 @@ export ROS2_INSTALL_PATH=$CC_WS/ros2_ws/install
 # Ignore some package
 touch \
     ros2_ws/src/ros2/rviz/COLCON_IGNORE \
-    ros2_ws/src/ros2/demos/intra_process_demo/COLCON_IGNORE \
-    ros2_ws/src/ros2/demos/image_tools/COLCON_IGNORE \
     ros2_ws/src/ros2/robot_state_publisher/COLCON_IGNORE
 
 cd ros2_ws

--- a/sysroot/Dockerfile_ubuntu_arm64
+++ b/sysroot/Dockerfile_ubuntu_arm64
@@ -81,3 +81,7 @@ RUN rosdep install --from-paths src \
         urdfdom_headers \
         libpoco-dev \
         libpocofoundation9"
+
+WORKDIR /
+RUN apt-get install -y symlinks
+RUN symlinks -rc .

--- a/sysroot/Dockerfile_ubuntu_armhf
+++ b/sysroot/Dockerfile_ubuntu_armhf
@@ -81,3 +81,7 @@ RUN rosdep install --from-paths src \
         urdfdom_headers \
         libpoco-dev \
         libpocofoundation9"
+
+WORKDIR /
+RUN apt-get install -y symlinks
+RUN symlinks -rc .


### PR DESCRIPTION
Improve the exported filesystem by:
- resolving the broken symlink by changing them to relative one with the "symlinks" tools 
- export /etc

This allow us to build more ROS2 packages