### PR TITLE
Add docker argument to specify the ros2 version

### DIFF
--- a/Dockerfile_cc_for_arm
+++ b/Dockerfile_cc_for_arm
@@ -52,10 +52,11 @@ RUN apt-get install -y docker-ce
 
 # 2. Download ROS2 src
 ENV CC_WS /root/cc_ws
+ARG ROS2_VERSION=release-bouncy
 
 WORKDIR $CC_WS/ros2_ws
 RUN mkdir src
-RUN wget https://raw.githubusercontent.com/ros2/ros2/release-bouncy/ros2.repos
+RUN wget https://raw.githubusercontent.com/ros2/ros2/${ROS2_VERSION}/ros2.repos
 RUN vcs-import src < ros2.repos
 RUN git clone https://github.com/ros2/cross_compile.git src/ros2/cross_compile
 


### PR DESCRIPTION
Use an argument to select which version of ROS2 to fetch. This can be specified with the `--build-arg` argument on the docker build command:
        docker build --build-arg ROS2_VERSION=release-crystal ...